### PR TITLE
fix: remove erro of empty task input

### DIFF
--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -18,7 +18,8 @@
           </div>
 
           <h3 class="mt-4">Tarefas:</h3>
-          <% if @list.items.exists? %>
+          <% @items ||= [] %> 
+          <% if @items.any? %> 
             <ul class="list-group mb-4">
               <% @items.each do |item| %>
                 <li class="list-group-item d-flex justify-content-between align-items-center">


### PR DESCRIPTION
## Motivação

Precisamos fazer essa mudança para que não de erro ao tentar criar um **Item** com texto vazio

## Resumo da adição/alteração

Proponho a seguinte mudança:
- Definir `@items` sempre como array para iteração correta

## Links

- Tarefa: #23 